### PR TITLE
Fix custommask

### DIFF
--- a/bin/processGradUnwarp
+++ b/bin/processGradUnwarp
@@ -130,8 +130,19 @@ fi
 
  echo applywarp --rel -i $dwi_vol -r $b0_t1_ref  -w $combined_warp --interp=spline -o $out_dwi_vol
  applywarp --rel -i $dwi_vol -r $b0_t1_ref  -w $combined_warp --interp=spline -o $out_dwi_vol
- echo applywarp --rel -i $brain_mask -r $b0_t1_ref  -w $combined_warp --interp=nn -o $out_brain_mask
- applywarp --rel -i $brain_mask -r $b0_t1_ref  -w $combined_warp --interp=nn -o $out_brain_mask
+ 
+ if [ "$custom_brainmask" = "1" ]
+ then
+   # if custom_brainmask was used, then that brainmask (from regT1 dir) should be gradcorrected already
+   # so, no need to compose T1 and gradunwarp, just need to resample regT1 brainmask into the same ref space (it might be already, but just to be safe..)
+   regT1_brain_mask=$regT1_dir/brainmask.nii.gz
+   echo reg_resample -flo $regT1_brain_mask -ref $b0_t1_ref -res $out_brain_mask -NN 0
+   reg_resample -flo $regT1_brain_mask -ref $b0_t1_ref -res $out_brain_mask -NN 0
+
+ else
+   echo applywarp --rel -i $brain_mask -r $b0_t1_ref  -w $combined_warp --interp=nn -o $out_brain_mask
+   applywarp --rel -i $brain_mask -r $b0_t1_ref  -w $combined_warp --interp=nn -o $out_brain_mask
+ fi
 
  else
 

--- a/bin/processRegT1
+++ b/bin/processRegT1
@@ -96,8 +96,21 @@ cp $dwi_bval $out_dir/dwi.bval
  #resample dwi to t1 space 
  echo flirt -in $dwi_vol -ref $b0_t1_ref -applyxfm -init $xfm_b0_t1 -interp spline -out $out_dir/dwi.nii.gz
  flirt -in $dwi_vol -ref $b0_t1_ref -applyxfm -init $xfm_b0_t1 -interp spline -out $out_dir/dwi.nii.gz
+
+#if custom_brainmask option was used (imported from T1 space), then use that instead of brainmask from previous dwi stage
+if [ "$custom_brainmask" = "1" ]
+then
+	t1_brain=$t1_dir/t1.brain.inorm.nii.gz
+	echo reg_resample -flo $t1_brain -ref $b0_t1_ref -res $out_dir/brainmask.nii.gz -NN 0
+	reg_resample -flo $t1_brain -ref $b0_t1_ref -res $out_dir/brainmask.nii.gz -NN 0
+	echo fslmaths $out_dir/brainmask.nii.gz -bin $out_dir/brainmask.nii.gz
+	fslmaths $out_dir/brainmask.nii.gz -bin $out_dir/brainmask.nii.gz
+else
+
  echo flirt -in $brain_mask -ref $b0_t1_ref -applyxfm -init $xfm_b0_t1 -interp nearestneighbour -out $out_dir/brainmask.nii.gz
  flirt -in $brain_mask -ref $b0_t1_ref -applyxfm -init $xfm_b0_t1 -interp nearestneighbour -out $out_dir/brainmask.nii.gz
+
+fi
 
 #crop tight around b0 (since t1 space is typically larger, also makes future processing quicker)
 roixyzt=`fslstats $b0_t1_ref -w`

--- a/prepdwi
+++ b/prepdwi
@@ -1122,6 +1122,9 @@ thisproduces=$subj_sess_prefix/dwi/${prevstep}_${thisstep}/dwi.nii.gz
  thisstep=regT1
  thisproduces=$subj_sess_prefix/dwi/${prevstep}_${thisstep}/dwi.nii.gz
 
+ export custom_brainmask
+
+
  if [ "$thisdisable" = "1" ]
  then
      prevstep=$prevstep


### PR DESCRIPTION
Enables use of custom brainmask (from beast or fmriprep) to mask DWI at the regT1 and grad_unwarp stage, assumes brainmask is from a grad-corrected T1w image..  