### PR TITLE
procEddy Origin Error Fix

### DIFF
--- a/bin/processEddy
+++ b/bin/processEddy
@@ -110,11 +110,13 @@ cp -v $dwi_bval $eddy_dir/dwi.bval
 
 # initial biascorrect
 # initial brainmasking with biascorrect
+# perform transform of masking to account for potential ants tolerance error in N4BiasFieldCorrection (JK - July 28, 2020)
 # final biascorrect with initial brainmask
 # final brainmasking with biascorrect 
 
 dwi_biascorrect_initial=$eddy_work/dwi_biascorrect_initial.nii.gz
 brainmask_initial=$eddy_work/brainmask_initial.nii.gz
+brainmask_fix=$eddy_work/brainmask_initial_fixed.nii.gz
 dwi_biascorrect_final=$eddy_dir/dwi.nii.gz
 brainmask_final=$eddy_dir/brainmask.nii.gz
 
@@ -123,6 +125,10 @@ dwibiascorrect -ants $dwi_vol $dwi_biascorrect_initial -fslgrad $dwi_bvec $dwi_b
 
 echo dwi2mask $dwi_biascorrect_initial $brainmask_initial -fslgrad $dwi_bvec $dwi_bval -force
 dwi2mask $dwi_biascorrect_initial $brainmask_initial -fslgrad $dwi_bvec $dwi_bval -force
+
+# Fix for image origin differences (JK - July 28, 2020)
+echo mrtransform $brainmask_initial -template $dwi_vol -interp nearest $brainmask_fix
+mrtransfrom $brainmask_initial -template $dwi_vol -interp nearest $brainmask_fix
 
 echo dwibiascorrect -mask $brainmask_initial -ants $dwi_vol $dwi_biascorrect_final -fslgrad $dwi_bvec $dwi_bval -force
 dwibiascorrect -mask $brainmask_initial -ants $dwi_vol $dwi_biascorrect_final -fslgrad $dwi_bvec $dwi_bval -force

--- a/bin/processEddy
+++ b/bin/processEddy
@@ -139,9 +139,6 @@ dwi2mask $dwi_biascorrect_final $brainmask_final -fslgrad $dwi_bvec $dwi_bval -f
 echo dtifit -k $dwi_biascorrect_final -o $eddy_dir/dti -m $brainmask_final -r $eddy_dir/dwi.bvec -b $eddy_dir/dwi.bval
 dtifit -k $dwi_biascorrect_final -o $eddy_dir/dti -m $brainmask_final -r $eddy_dir/dwi.bvec -b $eddy_dir/dwi.bval
 
-#make biascorrect the final dwi to use 
-#mv $dwi_v
-
 done
 
 

--- a/bin/processEddy
+++ b/bin/processEddy
@@ -130,8 +130,8 @@ dwi2mask $dwi_biascorrect_initial $brainmask_initial -fslgrad $dwi_bvec $dwi_bva
 echo mrtransform $brainmask_initial -template $dwi_vol -interp nearest $brainmask_fix
 mrtransform $brainmask_initial -template $dwi_vol -interp nearest $brainmask_fix
 
-echo dwibiascorrect -mask $brainmask_initial -ants $dwi_vol $dwi_biascorrect_final -fslgrad $dwi_bvec $dwi_bval -force
-dwibiascorrect -mask $brainmask_initial -ants $dwi_vol $dwi_biascorrect_final -fslgrad $dwi_bvec $dwi_bval -force
+echo dwibiascorrect -mask $brainmask_fix -ants $dwi_vol $dwi_biascorrect_final -fslgrad $dwi_bvec $dwi_bval -force
+dwibiascorrect -mask $brainmask_fix -ants $dwi_vol $dwi_biascorrect_final -fslgrad $dwi_bvec $dwi_bval -force
 
 echo dwi2mask $dwi_biascorrect_final $brainmask_final -fslgrad $dwi_bvec $dwi_bval -force
 dwi2mask $dwi_biascorrect_final $brainmask_final -fslgrad $dwi_bvec $dwi_bval -force

--- a/bin/processEddy
+++ b/bin/processEddy
@@ -133,8 +133,8 @@ dwi2mask $dwi_biascorrect_final $brainmask_final -fslgrad $dwi_bvec $dwi_bval -f
 echo dtifit -k $dwi_biascorrect_final -o $eddy_dir/dti -m $brainmask_final -r $eddy_dir/dwi.bvec -b $eddy_dir/dwi.bval
 dtifit -k $dwi_biascorrect_final -o $eddy_dir/dti -m $brainmask_final -r $eddy_dir/dwi.bvec -b $eddy_dir/dwi.bval
 
-#make biascorrect the final dwi to use
-mv $dwi_v
+#make biascorrect the final dwi to use 
+#mv $dwi_v
 
 done
 

--- a/bin/processEddy
+++ b/bin/processEddy
@@ -128,7 +128,7 @@ dwi2mask $dwi_biascorrect_initial $brainmask_initial -fslgrad $dwi_bvec $dwi_bva
 
 # Fix for image origin differences (JK - July 28, 2020)
 echo mrtransform $brainmask_initial -template $dwi_vol -interp nearest $brainmask_fix
-mrtransfrom $brainmask_initial -template $dwi_vol -interp nearest $brainmask_fix
+mrtransform $brainmask_initial -template $dwi_vol -interp nearest $brainmask_fix
 
 echo dwibiascorrect -mask $brainmask_initial -ants $dwi_vol $dwi_biascorrect_final -fslgrad $dwi_bvec $dwi_bval -force
 dwibiascorrect -mask $brainmask_initial -ants $dwi_vol $dwi_biascorrect_final -fslgrad $dwi_bvec $dwi_bval -force


### PR DESCRIPTION
Issue came up when preprocessing some 7T dataduring the `dwibiascorrect` command during the ANTS N4 correction call. Image origins were slightly off (between mask and the input dwi). 

Current PR fixes this by applying `mrtransform` to warp the mask such that the headers / image origins match. This does not actually check if the origins are different before applying the transform. The dwi and the mask should already be in the same space / have the same origin anyways so not quite sure where the difference popped up. 

An example of this error and fix can be found here: https://community.mrtrix.org/t/dwibiascorrect-ants-error/305/9

Additionally commented out last `mv` line within processEddy.